### PR TITLE
Fix effective directive for inline checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ base64 = "0.22"
 once_cell = "1.9"
 
 [features]
-serde = ["dep:serde", "bitflags/serde"]
+serde = ["dep:serde", "bitflags/serde", "url/serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,10 @@ impl CspList {
                 let report_sample = directive.value.iter().any(|t| &t[..] == "'report-sample'");
                 let violation = Violation {
                     resource: ViolationResource::Inline{ report_sample },
-                    directive: directive.clone(),
+                    directive: Directive {
+                        name: get_the_effective_directive_for_inline_checks(type_).to_owned(),
+                        value: directive.value.clone(),
+                    },
                 };
                 violations.push(violation);
                 if policy.disposition == PolicyDisposition::Enforce {


### PR DESCRIPTION
A directive can imply other directives. For example, the `script-src` implies the `script-src-elem` directive. Rather than returning the `script-src` as violated directive, we need to return `script-src-elem`.