### PR TITLE
Change resource type for inline checks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -667,7 +667,7 @@ impl CspList {
                     // on navigation request’s client’s global object, policy, and directive’s name.
                     violations.push(Violation {
                         // Step 3.1.1.4: Set violation’s resource to navigation request’s URL.
-                        resource: ViolationResource::Url(request.url.clone()),
+                        resource: ViolationResource::Inline { sample: None },
                         directive: Directive {
                             // Step 3.1.1.1: Let directive-name be the result of executing
                             // § 6.8.2 Get the effective directive for inline checks on type.


### PR DESCRIPTION
Unlike what's specified in the spec (
https://github.com/w3c/webappsec-csp/issues/719)
the tests assert that the resource is "inline":
https://github.com/web-platform-tests/wpt/blob/5726251d00e45c1ef06b0894dd843a93359c8f13/content-security-policy/navigation/to-javascript-url-script-src.html#L13