### PR TITLE
Add missing sandbox flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,15 +507,23 @@ impl CspList {
         // Step 2: Return false.
         (result, violations)
     }
+    /// <https://html.spec.whatwg.org/multipage/#csp-derived-sandboxing-flags>
     pub fn get_sandboxing_flag_set_for_document(&self) -> Option<SandboxingFlagSet> {
+        // Step 1. Let directives be an empty ordered set.
+        // Step 2. For each policy in cspList:
         self.0
             .iter()
             .flat_map(|policy| {
                 policy.directive_set
                     .iter()
+                    // Step 4. Let directive be directives[directives's size − 1].
+                    .rev()
+                    // Step 2.2. If policy's directive set contains a directive whose name is "sandbox",
+                    // then append that directive to directives.
                     .find(|directive| directive.name == "sandbox")
                     .and_then(|directive| directive.get_sandboxing_flag_set_for_document(policy))
             })
+            // Step 3. If directives is empty, then return an empty sandboxing flag set.
             .next()
     }
     /// https://www.w3.org/TR/CSP/#can-compile-strings
@@ -1370,18 +1378,15 @@ impl Directive {
             _ => Allowed
         }
     }
-    /// https://www.w3.org/TR/CSP/#sandbox-init
+    /// <https://html.spec.whatwg.org/multipage/#csp-derived-sandboxing-flags>
     pub fn get_sandboxing_flag_set_for_document(&self, policy: &Policy) -> Option<SandboxingFlagSet> {
-        use PolicyDisposition::*;
-        match &self.name[..] {
-            "sandbox" => {
-                if policy.disposition != Enforce {
-                    None
-                } else {
-                    Some(parse_a_sandboxing_directive(&self.value[..]))
-                }
-            },
-            _ => None,
+        debug_assert!(&self.name[..] == "sandbox");
+        // Step 2.1. If policy's disposition is not "enforce", then continue.
+        if policy.disposition != PolicyDisposition::Enforce {
+            None
+        } else {
+            // Step 5. Return the result of parsing the sandboxing directive directive.
+            Some(parse_a_sandboxing_directive(&self.value[..]))
         }
     }
     /// <https://w3c.github.io/webappsec-csp/#directive-pre-navigation-check>

--- a/src/sandboxing_directive.rs
+++ b/src/sandboxing_directive.rs
@@ -24,38 +24,68 @@ bitflags!{
         const SANDBOXED_ORIENTATION_LOCK_BROWSING_CONTEXT_FLAG = 0x00004000;
         const SANDBOXED_PRESENTATION_BROWSING_CONTEXT_FLAG = 0x00008000;
         const SANDBOXED_DOWNLOADS_BROWSING_CONTEXT_FLAG = 0x0010000;
+        const SANBOXED_CUSTOM_PROTOCOLS_NAVIGATION_BROWSING_CONTEXT_FLAG = 0x0020000;
     }
 }
 
+/// <https://html.spec.whatwg.org/multipage/#parse-a-sandboxing-directive>
 pub fn parse_a_sandboxing_directive(tokens: &[String]) -> SandboxingFlagSet {
+    // Step 1. Split input on ASCII whitespace, to obtain tokens.
+    //
+    // Performed by callers
+    // Step 2. Let output be empty.
+    //
+    // We inverse the logic here where we add all and then remove when required.
+    // This is why we don't need to explicitly add some flags, separate from the
+    // specification
     let mut output = SandboxingFlagSet::all();
+    // Step 3. Add the following flags to output:
     for token in tokens {
         let remove = match &token[..] {
-            "allow-downloads" => SandboxingFlagSet::SANDBOXED_DOWNLOADS_BROWSING_CONTEXT_FLAG,
+            // The sandboxed auxiliary navigation browsing context flag, unless tokens contains the allow-popups keyword.
             "allow-popups" =>
-                SandboxingFlagSet::SANDBOXED_AUXILIARY_NAVIGATION_BROWSING_CONTEXT_FLAG,
+                SandboxingFlagSet::SANDBOXED_AUXILIARY_NAVIGATION_BROWSING_CONTEXT_FLAG |
+                SandboxingFlagSet::SANBOXED_CUSTOM_PROTOCOLS_NAVIGATION_BROWSING_CONTEXT_FLAG,
+            // The sandboxed top-level navigation without user activation browsing context flag, unless tokens contains the allow-top-navigation keyword.
             "allow-top-navigation" =>
                 SandboxingFlagSet::SANDBOXED_TOP_LEVEL_NAVIGATION_WITHOUT_USER_ACTIVATION_BROWSING_CONTEXT_FLAG |
-                    SandboxingFlagSet::SANDBOXED_TOP_LEVEL_NAVIGATION_WITH_USER_ACTIVATION_BROWSING_CONTEXT_FLAG,
+                    SandboxingFlagSet::SANDBOXED_TOP_LEVEL_NAVIGATION_WITH_USER_ACTIVATION_BROWSING_CONTEXT_FLAG |
+                    SandboxingFlagSet::SANBOXED_CUSTOM_PROTOCOLS_NAVIGATION_BROWSING_CONTEXT_FLAG,
+            // The sandboxed top-level navigation with user activation browsing context flag, unless tokens contains either
+            // the allow-top-navigation-by-user-activation keyword or the allow-top-navigation keyword.
             "allow-top-navigation-by-user-activation" =>
                 SandboxingFlagSet::SANDBOXED_TOP_LEVEL_NAVIGATION_WITH_USER_ACTIVATION_BROWSING_CONTEXT_FLAG,
+            // The sandboxed origin browsing context flag, unless the tokens contains the allow-same-origin keyword.
             "allow-same-origin" =>
                 SandboxingFlagSet::SANDBOXED_ORIGIN_BROWSING_CONTEXT_FLAG,
+            // The sandboxed forms browsing context flag, unless tokens contains the allow-forms keyword.
             "allow-forms" =>
                 SandboxingFlagSet::SANDBOXED_FORMS_BROWSING_CONTEXT_FLAG,
+            // The sandboxed pointer lock browsing context flag, unless tokens contains the allow-pointer-lock keyword.
             "allow-pointer-lock" =>
                 SandboxingFlagSet::SANDBOXED_POINTER_LOCK_BROWSING_CONTEXT_FLAG,
+            // The sandboxed scripts browsing context flag, unless tokens contains the allow-scripts keyword.
+            // The sandboxed automatic features browsing context flag, unless tokens contains the allow-scripts keyword (defined above).
             "allow-scripts" =>
                 SandboxingFlagSet::SANDBOXED_SCRIPTS_BROWSING_CONTEXT_FLAG |
                     SandboxingFlagSet::SANDBOXED_AUTOMATIC_FEATURES_BROWSING_CONTEXT_FLAG,
+            // The sandbox propagates to auxiliary browsing contexts flag, unless tokens contains the allow-popups-to-escape-sandbox keyword.
             "allow-popups-to-escape-sandbox" =>
                 SandboxingFlagSet::SANDBOX_PROPOGATES_TO_AUXILIARY_BROWSING_CONTEXTS_FLAG,
+            // The sandboxed modals flag, unless tokens contains the allow-modals keyword.
             "allow-modals" =>
                 SandboxingFlagSet::SANDBOXED_MODALS_FLAG,
+            // The sandboxed orientation lock browsing context flag, unless tokens contains the allow-orientation-lock keyword.
             "allow-orientation-lock" =>
                 SandboxingFlagSet::SANDBOXED_ORIENTATION_LOCK_BROWSING_CONTEXT_FLAG,
+            // The sandboxed presentation browsing context flag, unless tokens contains the allow-presentation keyword.
             "allow-presentation" =>
                 SandboxingFlagSet::SANDBOXED_PRESENTATION_BROWSING_CONTEXT_FLAG,
+            // The sandboxed downloads browsing context flag, unless tokens contains the allow-downloads keyword.
+            "allow-downloads" => SandboxingFlagSet::SANDBOXED_DOWNLOADS_BROWSING_CONTEXT_FLAG,
+            // The sandboxed custom protocols navigation browsing context flag, unless tokens contains either the
+            // allow-top-navigation-to-custom-protocols keyword, the allow-popups keyword, or the allow-top-navigation keyword.
+            "allow-top-navigation-to-custom-protocols" => SandboxingFlagSet::SANBOXED_CUSTOM_PROTOCOLS_NAVIGATION_BROWSING_CONTEXT_FLAG,
             _ =>
                 SandboxingFlagSet::empty(),
         };

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -7,7 +7,7 @@ fn sandbox_document_flags() {
     let policy = CspList::parse("sandbox", PolicySource::Header, PolicyDisposition::Enforce);
     assert_eq!(Some(SandboxingFlagSet::all()), policy.get_sandboxing_flag_set_for_document());
     let policy = CspList::parse("sandbox allow-popups", PolicySource::Header, PolicyDisposition::Enforce);
-    assert_eq!(Some(SandboxingFlagSet::all() ^ SandboxingFlagSet::SANDBOXED_AUXILIARY_NAVIGATION_BROWSING_CONTEXT_FLAG), policy.get_sandboxing_flag_set_for_document());
+    assert_eq!(Some(SandboxingFlagSet::all() ^ SandboxingFlagSet::SANDBOXED_AUXILIARY_NAVIGATION_BROWSING_CONTEXT_FLAG ^ SandboxingFlagSet::SANBOXED_CUSTOM_PROTOCOLS_NAVIGATION_BROWSING_CONTEXT_FLAG), policy.get_sandboxing_flag_set_for_document());
     let policy = CspList::parse("sandbox allow-forms", PolicySource::Header, PolicyDisposition::Enforce);
     assert_eq!(Some(SandboxingFlagSet::all() ^ SandboxingFlagSet::SANDBOXED_FORMS_BROWSING_CONTEXT_FLAG), policy.get_sandboxing_flag_set_for_document());
     let policy = CspList::parse("sandbox allow-downloads", PolicySource::Header, PolicyDisposition::Enforce);
@@ -15,7 +15,7 @@ fn sandbox_document_flags() {
     let policy = CspList::parse("sandbox; connect-src https://*.notriddle.com:443", PolicySource::Header, PolicyDisposition::Enforce);
     assert_eq!(Some(SandboxingFlagSet::all()), policy.get_sandboxing_flag_set_for_document());
     let policy = CspList::parse("sandbox allow-popups; connect-src https://*.notriddle.com:443", PolicySource::Header, PolicyDisposition::Enforce);
-    assert_eq!(Some(SandboxingFlagSet::all() ^ SandboxingFlagSet::SANDBOXED_AUXILIARY_NAVIGATION_BROWSING_CONTEXT_FLAG), policy.get_sandboxing_flag_set_for_document());
+    assert_eq!(Some(SandboxingFlagSet::all() ^ SandboxingFlagSet::SANDBOXED_AUXILIARY_NAVIGATION_BROWSING_CONTEXT_FLAG ^ SandboxingFlagSet::SANBOXED_CUSTOM_PROTOCOLS_NAVIGATION_BROWSING_CONTEXT_FLAG), policy.get_sandboxing_flag_set_for_document());
     let policy = CspList::parse("connect-src https://*.notriddle.com:443", PolicySource::Header, PolicyDisposition::Enforce);
     assert_eq!(None, policy.get_sandboxing_flag_set_for_document());
 }


### PR DESCRIPTION
The SANBOXED_CUSTOM_PROTOCOLS_NAVIGATION_BROWSING_CONTEXT_FLAG was missing.

Discovered this by adding spec comments to all methods. Also discovered that we should take the last directive, not the first. Therefore, we have to reverse the iterator.